### PR TITLE
Signals button in mod button area, process library blueprints, temporary signals blueprint destruction

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,10 @@
 ---------------------------------------------------------------------------------------------------
+Version: 0.5.0
+Date: ????-??-??
+  Changes:
+    - Conversion button is now shown in mod button flow at top left instead of the mod flow on the left side.
+
+---------------------------------------------------------------------------------------------------
 Version: 0.4.0
 Date: 2021-10-06
   Changes:

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,8 @@ Version: 0.5.0
 Date: ????-??-??
   Changes:
     - Conversion button is now shown in mod button flow at top left instead of the mod flow on the left side.
+  Features:
+    - Signals can now be generated from library blueprints as well. Only entities can be read from them (no tiles, and no name/icon information).
 
 ---------------------------------------------------------------------------------------------------
 Version: 0.4.0

--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,8 @@ Date: ????-??-??
     - Conversion button is now shown in mod button flow at top left instead of the mod flow on the left side.
   Features:
     - Signals can now be generated from library blueprints as well. Only entities can be read from them (no tiles, and no name/icon information).
+  Bugfixes:
+    - Destruction of (temporary) signal blueprints is now properly handled when player invokes the clear-cursor (Q) control.
 
 ---------------------------------------------------------------------------------------------------
 Version: 0.4.0

--- a/control.lua
+++ b/control.lua
@@ -6,6 +6,7 @@ local GUI = require('gui')
 local modules = {
     Tempprint = require('modules/tempprint'),
     Signals   = require('modules/signals'),
+    GUI       = require('gui'),
 }
 
 

--- a/gui.lua
+++ b/gui.lua
@@ -77,34 +77,34 @@ function GUI.setup(player)
 end
 
 function GUI.update_visibility(player, force)
-    local pdata = global.playerdata[player.index]
-    if not pdata then
-        pdata = {}
-        global.playerdata[player.index] = pdata
+    -- Set-up player data if not already done so.
+    global.playerdata[player.index] = global.playerdata[player.index] or {}
+
+    local player_data = global.playerdata[player.index]
+    local player_is_holding_blueprint = player.is_cursor_blueprint()
+
+    -- No action required - force has not been requested, and button state already matches desired state.
+    if not force and player_data.buttons_enabled == player_is_holding_blueprint then
+        return
     end
 
-    local bp = (Util.get_blueprint(player.cursor_stack))
-    local enabled = (bp and bp.is_blueprint_setup()) and true or false
-    local was_enabled = pdata.buttons_enabled
-
-    if (not force and was_enabled ~= nil and enabled == was_enabled) then
-        return  -- No update needed.
-    end
-
+    -- Set visibility for all action buttons.
     for _, action in pairs(actions) do
         local button = mod_gui.get_button_flow(player)[action.name]
         if button then
-            button.visible = enabled
+            button.visible = player_is_holding_blueprint
         end
     end
 
+    -- Set visibility for all shortcuts.
     for name, action in pairs(actions) do
         if action.icon then
-            player.set_shortcut_available(name, enabled)
+            player.set_shortcut_available(name, player_is_holding_blueprint)
         end
     end
 
-    pdata.buttons_enabled = enabled
+    -- Store current visibility state for the player.
+    player_data.buttons_enabled = player_is_holding_blueprint
 end
 
 

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
     "name": "BlueprintSignals_continued",
-    "version": "0.4.0",
+    "version": "0.5.0",
     "title": "Blueprint Signals (continued)",
     "author": "Yenz",
     "contact": "https://github.com/JensForstmann/BlueprintSignals",

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -1,6 +1,8 @@
 [bpsignals]
 error-no_blueprint=Error: Must be holding a blueprint or blueprint book.
 error-invalid=Error: Blueprint must not be empty.
+error-clear_cursor=Error: Unable to clear the cursor.
+warning-blueprint_library=Warning: Only entities can be read from library blueprints.
 
 [controls]
 BlueprintSignals_convert=Convert to signals

--- a/modules/signals.lua
+++ b/modules/signals.lua
@@ -188,7 +188,7 @@ function Signals.blueprint_to_signals(player, event, action)
         stack.label_color = color
     end
 
-    Tempprint.set_temporary( player )
+    Tempprint.set_signals_blueprint( player, event.tick )
 end
 
 actions['BlueprintSignals_convert'].handler = Signals.blueprint_to_signals


### PR DESCRIPTION
The purpose of this pull request is to:

- Move the signals button into the mod button area, decoupling it from the Blueprinet Extensions mod in the process. This helps with button visibility, and helps when using additional mods such as YARM that make more substantial changes to the mod flow to the left.
- Add support for (limited) processing of blueprints stored in player/game library. Caveat is that tile and labeling information cannot be retrieved from such blueprints
- Fix destruction of temporary signal blueprints when player clears the cursor using the built-in input control. Signal blueprints are still preserved if player merely changes the stack being held, or when making modifications to the quick bar.